### PR TITLE
Show human emoji under selected buddy

### DIFF
--- a/main.js
+++ b/main.js
@@ -31,6 +31,7 @@ function play(e){
   if (e.target.classList.contains("buddy-button-image")) {
     game.playGame(e.target.id)
   }
+  show(e.target.nextElementSibling)
   message.innerText = game.message;
   humanWins.innerText = `Wins: ${game.human.wins}`;
   computerWins.innerText = `Wins: ${game.computer.wins}`;
@@ -75,6 +76,8 @@ function displayBeastGame() {
   hide(selectGameView);
   show(gameView);
   show(changeGameBtn);
+  show(bike);
+  show(brunch)
   game.type = "beast"
   message.innerText = "choose your bestest buddy"
   console.log(game)
@@ -86,6 +89,7 @@ function displayHome() {
   hide(brunch);
   hide(changeGameBtn);
   show(selectGameView);
+
   message.innerText = "choose your game"
 };
 

--- a/styles.css
+++ b/styles.css
@@ -82,6 +82,7 @@ body {
 
 .buddy-buttons {
   border: none;
+  max-height: 150px;
 }
 
 .buddy-buttons:hover {


### PR DESCRIPTION
#### What does  this PR do?
Displays the human emoji underneath the user's selected buddy. It does not yet clear them (hide them). The plan is to hide the one selected on the next bit of chronological functionality- when the user's selected buddy icon and the computer generated buddy icon 'face off' on the screen as a winner is assigned and points awarded.


#### Where should the reviewer start?
Not too much code difference, but the main.js file line 34 is where the magic happens.


#### How should this be manually tested?
Open index.html, select a game type, and then select a buddy and see the emoji face pop.

#### Any background context you want to provide?
NA

#### Screenshots (if appropriate)
NA

#### Questions:
NA