### PR TITLE
Fix local storage bug

### DIFF
--- a/player.js
+++ b/player.js
@@ -11,7 +11,8 @@ class Player {
   }
 
   retrieveWinsFromStorage() {
-    return (localStorage.getItem(`${this.name}Wins`))
+    this.wins = (localStorage.getItem(`${this.name}Wins`)) || 0
+    return this.wins
   }
 
   takeTurn(buddy) {


### PR DESCRIPTION
#### What does  this PR do?
Fixes the bug on viewing local storage.
If a user played a game, refreshed the page, then played a game again, the wins were resetting upon playing again. Fixed with very little added to retrieveFromStorage() method.


#### Where should the reviewer start?
Can check out the code but a manual test is better.

#### How should this be manually tested?
Open index.html and play a number of rounds of any combination of game. Refresh the page, play more games. The win counts will now continue to go up without being reset at any point.


#### Any background context you want to provide?
NA

#### Screenshots (if appropriate)
NA

#### Questions:
NA