### PR TITLE
Fix bug- disable change game button

### DIFF
--- a/main.js
+++ b/main.js
@@ -34,10 +34,23 @@ function playGame(e){
     createToken.innerText = game.human.token;
     game.determineWinner(e.target.id);
   }
+  disableChangeGameBtn();
   setTimeout(showFight, 700);
   setTimeout(displayUpdatedInfo, 700);
   setTimeout(resetGame, 2800);
 };
+
+function disableChangeGameBtn() {
+    changeGameBtn.classList.add("disabled-button");
+    changeGameBtn.classList.add("disabled-button:hover")
+    changeGameBtn.disabled = true;
+};
+
+function enableChangeGameBtn() {
+  changeGameBtn.classList.remove("disabled-button");
+  changeGameBtn.classList.remove("disabled-button:hover")
+  changeGameBtn.disabled = false;
+}
 
 function updateWinCount() {
   humanWins.innerText = game.human.retrieveWinsFromStorage() || 0
@@ -56,6 +69,7 @@ function resetGame() {
     displayBasicGame();
   }
   createToken.remove();
+  enableChangeGameBtn();
 };
 
 function showFight() {

--- a/styles.css
+++ b/styles.css
@@ -81,7 +81,6 @@ body {
   background-color: #D48258;
 }
 
-
 .buddy-button-image {
   max-width: 150px;
 }
@@ -125,6 +124,17 @@ body {
   cursor:pointer;
   background-color: white;
   color: #ECB983;
+}
+
+.disabled-button {
+  background-color: #DCDCDC;
+  color: #A9A9A9;
+}
+
+.disabled-button:hover {
+  cursor:not-allowed;
+  background-color: #DCDCDC;
+  color: #A9A9A9;
 }
 
 /* ~~~~~~~~~~ HIDDEN ~~~~~~~~~~~~ */


### PR DESCRIPTION
#### What does this PR do?
There was a bug/edge case that I needed to account for with the 'Change Game?' button. After a user selects their fighter (buddy), they have 700 milliseconds where they can still select the 'Select Game?' button before the view changes to the face-off view. If the 'Select Game?' button does happen to be selected in that window, that would then shoot the user back to that 'home view' BUT it would also continue to update the score and message. This would be displayed on the home view rather than on the face-off view.

I wrote a function that disables the button and changes the styling so the button now looks like, and is in fact, disabled. 

#### Where should the reviewer start?
The style page has two rules added for the button.
The main.js has two functions added- one to disable the button and one to enable the button. These functions are then invoked in other functions where necessary.

#### How should this be manually tested?
Open index.html. Play the game, try to click the 'Change Game?' button after you've selected your buddy but before the buddy face-off view appears. 

#### Any background context you want to provide?
No

#### Screenshots (if appropriate)
NA

#### Questions:
NA